### PR TITLE
Agrega repo de eventos

### DIFF
--- a/eventos/2014-09-03.yaml
+++ b/eventos/2014-09-03.yaml
@@ -1,0 +1,32 @@
+item: event
+name: ChelaJS
+series: chelajs
+meetup_id: dccwlkysmbfb
+venue:
+  id: 12455372
+  name: 'KMMX Centro de Capacitación en TI, Web y Mobile'
+spots: 80
+starts: 2014-09-03 20:00:00
+ends: 2014-09-03 22:00:00
+intro: !markdown >
+  La noche empieza a las 7:30 pm cuando nos vemos, platicamos un rato y nos conocemos un poco mas los fanaticos de la cerveza y el javascript. Antes de empezar con las pláticas a las 8:00.
+talks:
+  - speaker:
+      name: 'Armando González'
+      url: 'https://twitter.com/manduks'
+      bio: ''
+    title: 'JSDuck'
+    summary: 'Armando presenta una forma fácil y rápida de generar documentación de cualquier aplicación usando unas reglas sencillas al momento de escribir código.'
+  - speaker:
+      name: 'Alfonso Ruiz'
+      url: ''
+      bio: ''
+    title: 'TDD usando Jasmine'
+    summary: 'Test-driven-development usando Jasmine'
+  - speaker:
+      name: 'Antonio Sandoval'
+      url: 'http://twitter.com/__arch3r'
+      bio: ''
+    title: 'React + Socket.io'
+    summary: 'Antonio habla de las ventajas de usar React.js y Socket.io para un sistema bancario'
+footer: ''

--- a/eventos/2014-10-01.yaml
+++ b/eventos/2014-10-01.yaml
@@ -1,0 +1,31 @@
+item: event
+name: ChelaJS
+series: chelajs
+meetup_id: qhgrmkysnbcb
+venue:
+  id: 22074082
+  name: Centraal
+spots: 90
+starts: 2014-10-01 20:00:00
+ends: 2014-10-01 22:00:00
+intro: 'La noche empieza a las 7:30 pm cuando nos vemos, platicamos un rato y nos conocemos un poco mas los fanaticos de la cerveza y el javascript. Antes de empezar con las pláticas a las 8:00.'
+talks:
+  - speaker:
+      name: 'Daniel Zavala'
+      url: 'http://twitter.com/siedrix'
+      bio: ''
+    title: 'Paperpress'
+    summary: 'Daniel nos habla de paperpress, su proyecto para crear blogs.'
+  - speaker:
+      name: 'Erick Camacho'
+      url: 'http://twitter.com/ecamacho'
+      bio: ''
+    title: 'Historia de modelos de concurrencia: de Java a Javascript a Erlang'
+    summary: ''
+  - speaker:
+      name: 'Josué Gutierrez'
+      url: 'http://twitter.com/eusoj'
+      bio: ''
+    title: 'Angular + Monkey Learn'
+    summary: 'Integrar la herramienta de TextMining Monkey Learn con Angular'
+footer: ''

--- a/eventos/2014-11-19.yaml
+++ b/eventos/2014-11-19.yaml
@@ -1,0 +1,37 @@
+item: event
+name: ChelaJS
+series: chelajs
+meetup_id: qhgrmkyspbhb
+venue:
+  id: 22074082
+  name: Centraal
+spots: 90
+starts: 2014-11-19 20:00:00
+ends: 2014-11-19 22:00:00
+intro: 'La noche empieza a las 7:30 pm cuando nos vemos, platicamos un rato y nos conocemos un poco más los fanaticos de la cerveza y el Javascript. Las pláticas inician a las 8:00.'
+talks:
+  - speaker:
+      name: 'Charly Roman'
+      url: 'https://twitter.com/carlangueitor'
+      bio: ''
+    title: 'Convirtiendo animaciones HTML a video con SlimerJS, Node.js y ffmpeg'
+    summary: ''
+  - speaker:
+      name: 'Roberto Hidalgo'
+      url: 'https://twitter.com/unrob'
+      bio: 'Autodidacta Salvaje'
+    title: 'No uses Javascript'
+    summary: '(para todo)'
+  - speaker:
+      name: 'Rogelio Alberto'
+      url: 'https://twitter.com/rog3r'
+      bio: ''
+    title: 'Creando robots con CylonJS'
+    summary: ''
+  - speaker:
+      name: 'Leo Fischer'
+      url: ''
+      bio: 'CTO de Conekta'
+    title: 'Haciendo pruebas de frontend con CasperJS en el mundo real'
+    summary: ''
+footer: ''

--- a/eventos/2014-12-20.yaml
+++ b/eventos/2014-12-20.yaml
@@ -1,0 +1,22 @@
+item: event
+name: Posada.js
+series: chelajs
+meetup_id: 219110060
+venue:
+  id: 19850642
+  name: The Pool
+spots: 100
+starts: 2014-12-20 16:00:00
+ends: 2014-12-20 20:00:00
+intro: !markdown >
+  Terminemos el año compartiendo historias de Javascript.
+
+  El día comenzará a las 4PM, hora en la que nos reuniremos a conocernos y platicar. A partir de las 4:30 iniciaremos una [desconferencia](http://www.wikiwand.com/es/Desconferencia), lo cual significa que todos los asistentes pueden proponer una plática de 10 minutos para compartir sus historias o su mejor código del año.
+
+  Puedes revisar la [lista de pláticas](https://github.com/javascriptmx/posadajs/issues) o proponer una plática creando un issue ahí mismo.
+
+  A partir de las 7:30 veremos el árbol de navidad que la comunidad de Nodebots ha preparado para compartir.
+
+  El evento no tiene costo, pero se recomienda que lleves tu cerveza favorita.
+talks: []
+footer: ''

--- a/eventos/2015-01-07.yaml
+++ b/eventos/2015-01-07.yaml
@@ -1,0 +1,30 @@
+item: event
+name: 'ChelaJS: Mobile con Javascript'
+series: chelajs
+meetup_id: 219396408
+venue:
+  id: 22074082
+  name: Centraal
+spots: 85
+starts: 2015-01-07 20:00:00
+ends: 2015-01-07 22:00:00
+intro: !markdown >
+  La noche empieza a las 7:30 pm cuando nos vemos, platicamos un rato y nos conocemos un poco más los fanaticos de la cerveza y el Javascript. Las pláticas inician a las 8:00.
+
+  Esta ocasión compararemos dos tecnologías que nos permiten crear apps móviles usando Javascript. Encontramos dos ponentes que, más que darnos el intro a las librerías, nos platicarán sus experiencias creando productos para clientes.
+talks:
+  - speaker:
+      url: 'https://twitter.com/dmiramon'
+      name: Diego Miramontes
+    title: 'jQuery Mobile'
+  - speaker:
+      url: 'https://twitter.com/vampaynani'
+      name: Wenceslao Negrete
+    title: 'Ionic'
+    summary: ''
+  - speaker:
+      url: 'https://twitter.com/siedrix'
+      name: Daniel Zavala
+    title: 'CI para deployment a producción'
+    summary: 'Daniel nos comparte cómo usar integración continua para tener deploys automatizados a producción.'
+footer: ''

--- a/eventos/2015-02-04.yaml
+++ b/eventos/2015-02-04.yaml
@@ -1,0 +1,26 @@
+item: event
+name: ChelaJS Febrero
+series: chelajs
+meetup_id: 220165729
+venue:
+  id: 22074082
+  name: Centraal
+spots: 100
+starts: 2015-02-04 19:30:00
+ends: 2015-02-04 22:00:00
+intro: 'Nos reuniremos a tomar Javascript para hablar del mejor lenguaje de hoy en día: Cerveza. La noche empieza a las 7:30 pm cuando nos vemos, platicamos un rato y nos conocemos un poco más los fanaticos de la cerveza y el Javascript. Las pláticas inician a las 8:00.'
+talks:
+  - speaker:
+      url: 'https://github.com/juanjcsr'
+      name: 'Juan Carlos Sanchez'
+      bio: 'ingeniero en http://opi.la Open Intelligence'
+    title: Pipelines de desarrollo'
+    summary: ''
+  - speaker:
+      url: 'https://twitter.com/unrob'
+      name: 'Roberto Hidalgo'
+      bio: 'Autodidacta salvaje'
+    title: 'Una aplicación de chat avanzada con Node.js usando Socket.io'
+    summary: ''
+footer: ''
+zz_data: ""

--- a/eventos/2015-04-07.yaml
+++ b/eventos/2015-04-07.yaml
@@ -1,0 +1,34 @@
+item: event
+name: ChelaJS
+series: chelajs
+meetup_id: 221112495
+venue:
+  id: 22074082
+  name: Centraal
+spots: 100
+starts: 2015-04-07 20:00:00
+ends: 2015-04-07 22:00:00
+intro: !markdown >
+  Regresamos al meetup que nos permite tomar Javascript y hablar del mejor lenguaje de programación hoy en día: Cerveza.
+
+  La noche empieza a las 7:30 pm cuando nos vemos, platicamos un rato y nos conocemos un poco más los fanaticos de la cerveza y el Javascript. Las pláticas inician a las 8:00.
+talks:
+  - speaker:
+      url: ''
+      bio: ''
+      name: 'Juan Álvarez'
+    title: 'Frameworks para el front-end'
+    summary: 'Juan nos platica de su proceso para seleccionar una librería en el cliente, que lo ha llevado ha pasar por Actionscript, jQuery, Cappuccino, SproutCore, Ember, Angular y finalmente a React'
+  - speaker:
+      url: 'https://twitter.com/memoPilgrim'
+      name: 'Guillermo Vilchis'
+      bio: ''
+    title: 'De Java a Angular'
+    summary: 'Guillermo nos habla un poco de cómo fue su transición de escribir Java empresarial a Angular.JS'
+  - speaker:
+      url: 'https://github.com/hpneo'
+      name: 'Gustavo León'
+      bio: ''
+    title: 'gmaps.js'
+    summary: 'Gustavo nos platica de sus experiencias creando y contribuyendo en un proyecto con más de 1000 estrellas en Github'
+footer: ''

--- a/eventos/2015-06-03.yaml
+++ b/eventos/2015-06-03.yaml
@@ -1,0 +1,35 @@
+item: event
+name: ChelaJS
+series: chelajs
+meetup_id: 222835517
+venue:
+  id: 23873464
+  name: Nearsoft
+spots: 100
+starts: 2015-06-03 20:00:00
+ends: 2015-06-03 22:00:00
+intro: !markdown >
+  Los esperamos en el que nos permite tomar Javascript y hablar del mejor lenguaje de programación hoy en día: Cerveza.
+
+  La noche empieza a las 7:30 pm cuando nos vemos, platicamos un rato y nos conocemos un poco más los fanaticos de la cerveza y el Javascript. Las pláticas inician a las 8:00.
+talks:
+  - speaker:
+      url: 'https://github.com/pateketrueke'
+      name: 'Álvaro Cabrera'
+      bio: ''
+    title: 'Ractive.js'
+    summary: 'Álvaro comparte Ractive.js, un framework ligero para frontend que contiene bindings de dos sentidos.'
+  - speaker:
+      url: 'https://github.com/SergioMartinezP'
+      name: 'Sergio Martinez'
+      bio: ''
+    title: 'Mitigación de ataques con NodeJS'
+    summary: 'Serch nos habla de los 10 ataques más comunes en web y cómo mitigarlos con Node.'
+  - speaker:
+      url: 'https://github.com/nez'
+      name: 'Andrés Gomez'
+      bio: ''
+    title: 'Clojurescript'
+    summary: 'Andrés nos habla de Clojurescript, un lenguaje que compila a Javascript y que permite escribir código funcional.'
+footer: !markdown >
+  Puedes comentar de este y más eventos en http://chat.javascriptmx.com

--- a/eventos/2015-07-01.yaml
+++ b/eventos/2015-07-01.yaml
@@ -1,0 +1,35 @@
+item: event
+name: ChelaJS
+series: chelajs
+meetup_id: 223581252
+venue:
+  id: 23873464
+  name: Nearsoft
+spots: 115
+starts: 2015-07-01 19:30:00
+ends: 2015-07-01 22:00:00
+intro: !markdown >
+  Los esperamos en el que nos permite tomar Javascript y hablar del mejor lenguaje de programación hoy en día: Cerveza.
+
+  La noche empieza a las 7:30 pm cuando nos vemos, platicamos un rato y nos conocemos un poco más los fanaticos de la cerveza y el Javascript. Las pláticas inician a las 8:00. [Por favor sean puntales para iniciar las platicas a tiempo].
+talks:
+  - speaker:
+      name: 'Marcela Lango'
+      url: 'https://github.com/bleedingxedge'
+      bio: ''
+    title: 'Data viz con JS'
+    summary: ''
+  - speaker:
+      name: 'Oscar Vega'
+      url: 'https://github.com/oscarvegar'
+      bio: ''
+    title: 'Sails.js'
+    summary: ''
+  - speaker:
+      name: 'Fernando Altuzar'
+      url: 'https://github.com/altuzar'
+      bio: ''
+    title: 'React Native'
+    summary: ''
+footer: !markdown >
+  Puedes comentar de este y más eventos en http://chat.javascriptmx.com

--- a/eventos/2015-08-05.yaml
+++ b/eventos/2015-08-05.yaml
@@ -1,0 +1,38 @@
+item: event
+name: ChelaJS
+series: chelajs
+meetup_id: 224311237
+venue:
+  id: 23873464
+  name: Nearsoft
+spots: 120
+starts: 2015-08-05 19:30:00
+ends: 2015-08-05 22:00:00
+intro: !markdown >
+  Los esperamos en el que nos permite tomar Javascript y hablar del mejor lenguaje de programación hoy en día: Cerveza.
+
+  La noche empieza a las 7:30 pm cuando nos vemos, platicamos un rato y nos conocemos un poco más los fanaticos de la cerveza y el Javascript. Las pláticas inician a las 8:00 [Por favor sean puntales para iniciar las platicas a tiempo].
+talks:
+  - speaker:
+      name: 'Óscar González'
+      url: 'https://twitter.com/mexicanhacker'
+      bio: "Oscar trabaja como Principal Software Engineer en Sawyer Effect, principalmente trabaja en proyectos de ecommerce para empresas como Nike, Converse, Macy's, etc. Actualmente se encuentra liderando el area de devops para enviar a producción un sitio de e-commerce hecho en node.js y Clojure."
+    title: 'Node.js en producción con Ansible'
+    summary: 'Un par de lecciones aprendidas al hacer deployment a producción con Ansible.'
+  - speaker:
+      name: 'Omar Sharim'
+      url: 'https://twitter.com/osharim'
+      bio: 'Computer Scientist behind Bentel México and Teslle'
+    title: '¿Por qué 0.1 + 0.2 no es 0.3?'
+    summary: 'La aritmética simple no es tan simple al tratarse de números flotantes y computadoras. Esta plática explica porqué, y qué podemos hacer al respecto.'
+  - speaker:
+      name: 'Richard Kaufman'
+      url: 'https://twitter.com/sparragus'
+      bio: 'Creative Hacker en el Laboratorio del Error Diseñado'
+    title: 'Programación de Bots para Slack'
+    summary: '¿Qué son los bots y qué hacen? Esta es una introducción al API de Slack, presentado a través de ejemplos en código para cada uno de los tipos de bots.'
+footer: !markdown >
+  Puedes comentar de este y más eventos en http://chat.javascriptmx.com
+
+
+  Les recordamos que los eventos de la comunidad JavascriptMX se rigen por nuestro [Código de Conducta](https://github.com/nodeschool/mexicocity/blob/master/codeofconduct.md).

--- a/eventos/2015-09-02.yaml
+++ b/eventos/2015-09-02.yaml
@@ -1,0 +1,42 @@
+item: event
+name: ChelaJS
+series: chelajs
+meetup_id: 224953040
+venue:
+  id: 23853304
+  name: 'KMMX Centro de Capacitación en TI, Web y Mobile'
+spots: 110
+starts: 2015-09-02 19:30:00
+ends: 2015-09-02 22:00:00
+intro: !markdown >
+  Los esperamos en el que nos permite tomar Javascript y hablar del mejor lenguaje de programación hoy en día: Cerveza.
+
+
+  La noche empieza a las 7:30 pm cuando nos vemos, platicamos un rato y nos conocemos un poco más los fanaticos de la cerveza y el Javascript. Las pláticas inician a las 8:00.
+
+
+  Por favor sean puntales para iniciar las platicas a tiempo.
+talks:
+  - speaker:
+      name: 'Miguel Cobá'
+      url: 'https://twitter.com/MiguelCobaMtz'
+      bio: ''
+    title: 'ECMAScript 6. ¿Qué hay de nuevo?'
+    summary: 'Javascript sigue evolucionando, esta plática nos explica las ventajas de usar las nuevas funcionalidades del lenguaje y cómo aprovecharlas mejor.'
+  - speaker:
+      name: 'Daniel Zavala'
+      url: 'https://twitter.com/siedrix'
+      bio: ''
+    title: 'Presente y futuro de javascript'
+    summary: 'El futuro del lenguaje pinta bien, y Daniel nos va a contar su experiencia al irlo viendo crecer.'
+  - speaker:
+      name: 'Jaime Rodas'
+      url: 'https://twitter.com/scylax'
+      bio: ''
+    title: 'Javascript: La solución a todos nuestros problemas'
+    summary: '¿El futuro del lenguaje pinta bien? Jaime nos cuenta sus observaciones con un ojo a lo que viene en el ecosistema de los navegadores, las opciones de los usuarios, y cómo otras ingenierías pueden aportar a este campo.'
+footer: !markdown >
+  Puedes comentar de este y más eventos en http://chat.javascriptmx.com
+
+
+  Les recordamos que los eventos de la comunidad JavascriptMX se rigen por nuestro [Código de Conducta](https://github.com/nodeschool/mexicocity/blob/master/codeofconduct.md).

--- a/eventos/2015-10-07.yaml
+++ b/eventos/2015-10-07.yaml
@@ -1,0 +1,40 @@
+item: event
+name: ChelaJS
+series: chelajs
+meetup_id: 225836383
+venue:
+  id: 23853304
+  name: 'KMMX Centro de Capacitación en TI, Web y Mobile'
+spots: 130
+starts: 2015-10-07 19:30:00
+ends: 2015-10-07 22:00:00
+intro: !markdown >
+  Los esperamos en el que nos permite tomar Javascript y hablar del mejor lenguaje de programación hoy en día: Cerveza.
+
+  La noche empieza a las 7:30 pm cuando nos vemos, platicamos un rato y nos conocemos un poco más los fanaticos de la cerveza y el Javascript. Las pláticas inician a las 8:00. Por favor sean puntales para iniciar las platicas a tiempo.
+
+  Recuerda que recibimos propuestas de pláticas en [https://github.com/javascriptmx/chelajs/](https://github.com/javascriptmx/chelajs)
+talks:
+  - speaker:
+      name: Sergio Martínez
+      url: https://twitter.com/SuperSerch
+      bio: 'Java Developer with a twist in security. DevOPS & OpenStack enthusiast. OWASP Member.'
+    title: Pruebas de Estrés
+    summary: 'Una introducción a las pruebas de estrés y algunos puntos a considerar en su planeación y ejecución.'
+  - speaker:
+      name: Jeduan Cornejo
+      url: https://twitter.com/jeduan
+      bio: 'Se pronuncia Yeduán. Sí, así me llamo.'
+    title: Node v4.0
+    summary: 'Hay nueva versión de Node.js y aquí platicamos de lo que implica para nuestros proyectos. Desde cómo terminamos aquí hasta qué esperar en el futuro cercano.'
+  - speaker:
+      name: Alberto Alcocer
+      url: https://twitter.com/beco
+      bio: No le tocó usar tarjetas perforadas.
+    title: Cuando JS no era útil
+    summary: 'Hace una década usábamos Javascript como una herramienta muy distinta a la que conocemos hoy. En esta charla escucharás de la evolución del lenguaje a través de sus buenos —y malos— usos.'
+footer: !markdown >
+  Puedes comentar de este y más eventos en [http://chat.javascriptmx.com](http://chat.javascriptmx.com)
+
+
+  Les recordamos que los eventos de la comunidad JavascriptMX se rigen por nuestro [Código de Conducta](https://github.com/nodeschool/mexicocity/blob/master/codeofconduct.md)

--- a/eventos/2015-11-04.yaml
+++ b/eventos/2015-11-04.yaml
@@ -1,0 +1,58 @@
+item: event
+name: ChelaJS Noviembre
+series: chelajs
+meetup_id: 226360040
+venue:
+  id: 23853304
+  name: Mercado Libre
+spots: 100
+starts: 2015-11-04 19:30:00
+ends: 2015-11-04 22:00:00
+intro: !markdown >
+  Los esperamos en el que nos permite tomar Javascript y hablar del mejor lenguaje de programación hoy en día: Cerveza.
+
+
+  La noche empieza a las 7:30 pm cuando nos vemos, platicamos un rato y nos conocemos un poco más los fanaticos de la cerveza y el Javascript. Las pláticas inician a las 8:00.
+
+
+  Por favor sean puntales para iniciar las platicas a tiempo.
+
+
+  **En la entrada di que vienes al Piso 9 a Mercado Libre**
+
+
+  Recuerda que recibimos propuestas de pláticas en [nuestro repo en github](https://github.com/javascriptmx/chelajs/).
+
+
+  ¿Te quedaste sin lugar o no puede llegar? Sigue el streaming en nuestro canal de [Youtube](https://www.youtube.com/channel/UCsmWJI_UTYDbggvYoOATcIQ).
+talks:
+  - speaker:
+      name: Miguel Rubalcava
+      url: https://twitter.com/mark_gram
+      bio: DevOps y amante de IoT
+      pic: https://pbs.twimg.com/profile_images/637910620960980994/tnYk55dG_400x400.jpg
+    title: Electrificando la casa con node
+    summary: "Hacer domótica resulta sencillo con la ayuda de Node.js y X10, un protocolo de comunicación que utiliza la red eléctrica como medio de transporte. En esta plática Mike nos comparte una faceta más de lo que podemos crear con Node.js y un presupuesto pequeño, a través de su experiencia conectando dispositivos mediante Javascript."
+  - speaker:
+      name: Marcela Lango
+      url: https://twitter.com/marulango
+      bio: Full Stack Designer; Women Who Code DF; Nodeschool Mexico City; Pokemon Master
+      pic: https://pbs.twimg.com/profile_images/445400536569749504/8vJ-Prbe.png
+    title: '"Let me show you how to graph it"'
+    summary: "P5.js nos acerca al poder de Processing con la omnipresencia de Javascript. Maru nos muestra cómo sacarle jugo a una multitud de datos haciendo visualizaciones directamente en el navegador sin tener que lidiar directamente con el <canvas>"
+  - speaker:
+      name: Bruno Medina
+      url: https://twitter.com/brusMX
+      bio: Microsoft México Technical Evangelist obsesionado con la tecnología y el café.
+      pic: https://pbs.twimg.com/profile_images/643666640706506752/L3pNtSnY.jpg
+    title: Apps universales con Apache Cordova
+    summary: "Sólo basta con escribir Javascript y usar herramientas de software libre para poder generar una base de código re-utilizable en el browser, iOS, Android, y UWP. Bruno nos va a mostrar como trabajar eficientemente con estas herramientas y mantener la cordura."
+sponsors:
+  - name: Mercado Libre
+    url: http://www.mercadolibre.com/org-img/empleos/index.html
+    pic: http://photos2.meetupstatic.com/photos/sponsor/c/a/1/5/iab120x90_2571733.jpeg
+footer: !markdown >
+  Puedes comentar de este y más eventos en http://chat.javascriptmx.com
+
+
+  Les recordamos que los eventos de la comunidad JavascriptMX se rigen por nuestro [Código de Conducta](https://github.com/nodeschool/mexicocity/blob/master/codeofconduct.md).


### PR DESCRIPTION
Usé el API de meetup para bajar el historial de eventos y convertirlos a markdown, estructurando conforme a lo descrito en el HTML del evento.

Este repo finalmente será **autoritativo** de los eventos de chelajs, y al ser integrado con [meethub](https://github.com/unRob/meethub), publicará automáticamente en meethub y en chelajs.com