### PR TITLE
feat: add new conditions

### DIFF
--- a/JOB_POSTINGS.md
+++ b/JOB_POSTINGS.md
@@ -4,7 +4,7 @@
 
 ### Etiqueta para usuarios en general
 
-En este canal solo se permiten anuncios de personas que desean publicar una vacante o que estén buscando empleo, cualquier mensaje que no sea de la persona que publica será borrado. A su vez, los únicos mensajes permitidos para el publicante serán aclaraciones.
+En este canal sólo se permite publicar o solicitar ofertas de empleo; cualquier mensaje de otra naturaleza será borrado. 
 
 Si tienes alguna duda sobre cualquier vacante, contáctate con el autor de la publicación por DM.
 

--- a/JOB_POSTINGS.md
+++ b/JOB_POSTINGS.md
@@ -4,7 +4,7 @@
 
 ### Etiqueta para usuarios en general
 
-En este canal solo se permiten anuncios de personas que postear una vacante, cualquier mensaje que no sea del OP sera borrado, los únicos mensajes permitidos para él OP serán aclaraciones.
+En este canal solo se permiten anuncios de personas que desean publicar una vacante o que estén buscando empleo, cualquier mensaje que no sea del OP sera borrado, los únicos mensajes permitidos para él OP serán aclaraciones.
 
 Si tienes alguna duda sobre cualquier vacante, contáctate con él OP por DM.
 

--- a/JOB_POSTINGS.md
+++ b/JOB_POSTINGS.md
@@ -2,6 +2,18 @@
 
 ¡Bienvenido al canal de #job-posts de Eventloop! Este documento te ayudará a compartirnos una oferta de empleo.
 
+### Etiqueta para usuarios en general
+
+En este canal solo se permiten anuncios de personas que postear una vacante, cualquier mensaje que no sea del OP sera borrado, los únicos mensajes permitidos para él OP serán aclaraciones.
+
+Si tienes alguna duda sobre cualquier vacante, contáctate con él OP por DM.
+
+###  Etiqueta para personal que posteen vacantes
+
+Si tu post no cumple cons nuestros guidelines este puede ser borrado, antes de ser borrado un admin se contactara con el OP para darle una oportunidad de modificarlo para que se alinee con nuestros guidelines.
+
+Algún post que no cumple totalmente con los lineamientos puede permanecer, pero solo si el admin considera que el post es una buena oportunidad para la comunidad *as is*, un emoji de ✔ de alguno de los admin significa que el post seguirá en el canal.
+
 Recuerda que esta comunidad es una comunidad enfocada en el lenguaje JavaScript, tómalo en cuenta antes de publicar tu post. 
 
 Una descripción de la oferta completa con información de calidad te ayudará a conseguir los mejores candidatos para esta posición. Además, ayudarás a la comunidad a poder elegir mejor a qué empresas acercarse. En el mundo del desarrollo de software la demanda por desarrolladores es muy alta. Una descripción muy bien redactada puede hacer toda la diferencia entre decidir contestar o no un post.

--- a/JOB_POSTINGS.md
+++ b/JOB_POSTINGS.md
@@ -10,7 +10,7 @@ Si tienes alguna duda sobre cualquier vacante, contáctate con el autor de la pu
 
 ###  Etiqueta para personas que publican vacantes
 
-Si tu publicación no cumple con nuestros lineamientos, éste puede ser borrado. Antes de ser borrado un administrador se pondrá en contacto con el OP para darle oportunidad de modificarlo.
+Si tu publicación no cumple con nuestros lineamientos, éste puede ser borrado. Antes de ser borrado un administrador se pondrá en contacto con el autor de la publicación para darle oportunidad de modificarlo.
 
 Alguna publicación que no cumpla totalmente con los lineamientos puede permanecer, pero sólo si un administrador considera que la publicación es una buena oportunidad para la comunidad, un emoji de ✔ de alguno de los administradores significa que la publicación podrá permanencer en el canal.
 

--- a/JOB_POSTINGS.md
+++ b/JOB_POSTINGS.md
@@ -12,7 +12,7 @@ Si tienes alguna duda sobre cualquier vacante, contáctate con el autor de la pu
 
 Si tu publicación no cumple con nuestros lineamientos, éste puede ser borrado. Antes de ser borrado un administrador se pondrá en contacto con el autor de la publicación para darle oportunidad de modificarlo.
 
-Alguna publicación que no cumpla totalmente con los lineamientos puede permanecer, pero sólo si un administrador considera que la publicación es una buena oportunidad para la comunidad, un emoji de ✔ de alguno de los administradores significa que la publicación podrá permanencer en el canal.
+Cualquier publicación, aunque que no cumpla totalmente con los lineamientos, puede permanecer siempre y cuando un administrador considere que representa una buena oportunidad para la comunidad. Dichas publicaciones serán señaladas con un emoji de ✔para denotar que puede han sido aprobadas por un admin.
 
 Recuerda que esta comunidad es una comunidad enfocada en el lenguaje JavaScript, tómalo en cuenta antes de publicar tu post. 
 

--- a/JOB_POSTINGS.md
+++ b/JOB_POSTINGS.md
@@ -8,7 +8,7 @@ En este canal solo se permiten anuncios de personas que desean publicar una vaca
 
 Si tienes alguna duda sobre cualquier vacante, contáctate con el OP por DM.
 
-###  Etiqueta para personal que posteen vacantes
+###  Etiqueta para personas que publican vacantes
 
 Si tu publicación no cumple con nuestros lineamientos, éste puede ser borrado. Antes de ser borrado un administrador se pondrá en contacto con el OP para darle oportunidad de modificarlo.
 

--- a/JOB_POSTINGS.md
+++ b/JOB_POSTINGS.md
@@ -4,7 +4,7 @@
 
 ### Etiqueta para usuarios en general
 
-En este canal solo se permiten anuncios de personas que desean publicar una vacante o que estén buscando empleo, cualquier mensaje que no sea del OP sera borrado, los únicos mensajes permitidos para él OP serán aclaraciones.
+En este canal solo se permiten anuncios de personas que desean publicar una vacante o que estén buscando empleo, cualquier mensaje que no sea de la persona que publica será borrado. A su vez, los únicos mensajes permitidos para el publicante serán aclaraciones.
 
 Si tienes alguna duda sobre cualquier vacante, contáctate con el OP por DM.
 

--- a/JOB_POSTINGS.md
+++ b/JOB_POSTINGS.md
@@ -6,7 +6,7 @@
 
 En este canal solo se permiten anuncios de personas que desean publicar una vacante o que estén buscando empleo, cualquier mensaje que no sea del OP sera borrado, los únicos mensajes permitidos para él OP serán aclaraciones.
 
-Si tienes alguna duda sobre cualquier vacante, contáctate con él OP por DM.
+Si tienes alguna duda sobre cualquier vacante, contáctate con el OP por DM.
 
 ###  Etiqueta para personal que posteen vacantes
 

--- a/JOB_POSTINGS.md
+++ b/JOB_POSTINGS.md
@@ -2,7 +2,7 @@
 
 ¡Bienvenido al canal de #job-posts de Eventloop! Este documento te ayudará a compartirnos una oferta de empleo.
 
-### Etiqueta para usuarios en general
+### Lineamientos para usuarios en general
 
 En este canal sólo se permite publicar o solicitar ofertas de empleo; cualquier mensaje de otra naturaleza será borrado. 
 

--- a/JOB_POSTINGS.md
+++ b/JOB_POSTINGS.md
@@ -6,7 +6,7 @@
 
 En este canal solo se permiten anuncios de personas que desean publicar una vacante o que estén buscando empleo, cualquier mensaje que no sea de la persona que publica será borrado. A su vez, los únicos mensajes permitidos para el publicante serán aclaraciones.
 
-Si tienes alguna duda sobre cualquier vacante, contáctate con el OP por DM.
+Si tienes alguna duda sobre cualquier vacante, contáctate con el autor de la publicación por DM.
 
 ###  Etiqueta para personas que publican vacantes
 

--- a/JOB_POSTINGS.md
+++ b/JOB_POSTINGS.md
@@ -10,7 +10,7 @@ Si tienes alguna duda sobre cualquier vacante, contáctate con el autor de la pu
 
 ###  Etiqueta para personas que publican vacantes
 
-Si tu publicación no cumple con nuestros lineamientos, éste puede ser borrado. Antes de ser borrado un administrador se pondrá en contacto con el autor de la publicación para darle oportunidad de modificarlo.
+Si tu publicación no cumple con nuestros lineamientos, un administrador se pondrá en contacto para explicar dónde existen deficiencias y tengas oportunidad de modificarlo. De otro modo se elimina la publicación.
 
 Cualquier publicación, aunque que no cumpla totalmente con los lineamientos, puede permanecer siempre y cuando un administrador considere que representa una buena oportunidad para la comunidad. Dichas publicaciones serán señaladas con un emoji de ✔para denotar que puede han sido aprobadas por un admin.
 

--- a/JOB_POSTINGS.md
+++ b/JOB_POSTINGS.md
@@ -12,7 +12,7 @@ Si tienes alguna duda sobre cualquier vacante, contáctate con él OP por DM.
 
 Si tu post no cumple cons nuestros guidelines este puede ser borrado, antes de ser borrado un admin se contactara con el OP para darle una oportunidad de modificarlo para que se alinee con nuestros guidelines.
 
-Algún post que no cumple totalmente con los lineamientos puede permanecer, pero solo si el admin considera que el post es una buena oportunidad para la comunidad *as is*, un emoji de ✔ de alguno de los admin significa que el post seguirá en el canal.
+Alguna publicación que no cumpla totalmente con los lineamientos puede permanecer, pero sólo si un administrador considera que la publicación es una buena oportunidad para la comunidad, un emoji de ✔ de alguno de los administradores significa que la publicación podrá permanencer en el canal.
 
 Recuerda que esta comunidad es una comunidad enfocada en el lenguaje JavaScript, tómalo en cuenta antes de publicar tu post. 
 

--- a/JOB_POSTINGS.md
+++ b/JOB_POSTINGS.md
@@ -10,7 +10,7 @@ Si tienes alguna duda sobre cualquier vacante, contáctate con el OP por DM.
 
 ###  Etiqueta para personal que posteen vacantes
 
-Si tu post no cumple cons nuestros guidelines este puede ser borrado, antes de ser borrado un admin se contactara con el OP para darle una oportunidad de modificarlo para que se alinee con nuestros guidelines.
+Si tu publicación no cumple con nuestros lineamientos, éste puede ser borrado. Antes de ser borrado un administrador se pondrá en contacto con el OP para darle oportunidad de modificarlo.
 
 Alguna publicación que no cumpla totalmente con los lineamientos puede permanecer, pero sólo si un administrador considera que la publicación es una buena oportunidad para la comunidad, un emoji de ✔ de alguno de los administradores significa que la publicación podrá permanencer en el canal.
 


### PR DESCRIPTION
Para promover el posteo de vacantes proponemos cambiar un poco las reglas del canal job postings.

El tl;dr es que ya no se puede responder a los job postings pero a cambio el equipo de admins en slack se compromete a moderar los posts.

Este lo hacemos porque cada job post es único pero uno de los requerimientos que más buscaremos que no cumplan los posts será que especifique el rango salarial.